### PR TITLE
Add topics getter to amqp broker

### DIFF
--- a/unipipeline/brokers/uni_amqp_py_broker.py
+++ b/unipipeline/brokers/uni_amqp_py_broker.py
@@ -148,6 +148,10 @@ class UniAmqpPyBroker(UniBroker[UniAmqpPyBrokerConfig]):
         self._heartbeat_delay = max(self.config.heartbeat / 4, 0.2)
         self._heartbeat_thread: Optional[threading.Thread] = None
 
+    @property
+    def initialized_topics(self) -> Set[str]:
+        return self._initialized_topics
+
     def _close_ch(self, ch: amqp.Channel) -> None:
         ch_id = ch.channel_id
         try:


### PR DESCRIPTION
Intended to use it before checking the message count of the topic, because if the queue isn't defined in broker get_messages_count fails with retries